### PR TITLE
Added seal.CoeffModulus.MaxBitCount

### DIFF
--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -134,6 +134,8 @@ PYBIND11_MODULE(seal, m)
 			 [](std::size_t poly_modulus_degree) { return CoeffModulus::BFVDefault(poly_modulus_degree); })
 		.def("Create",
 			 [](std::size_t poly_modulus_degree, std::vector<int> bit_sizes) { return CoeffModulus::Create(poly_modulus_degree, bit_sizes); });
+		.def("MaxBitCount",
+			 [](std::size_t poly_modulus_degree) { return CoeffModulus::MaxBitCount(poly_modulus_degree); });
 
 	// PlainModulus
 	py::class_<PlainModulus>(m, "PlainModulus")

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -133,7 +133,7 @@ PYBIND11_MODULE(seal, m)
 		.def("BFVDefault",
 			 [](std::size_t poly_modulus_degree) { return CoeffModulus::BFVDefault(poly_modulus_degree); })
 		.def("Create",
-			 [](std::size_t poly_modulus_degree, std::vector<int> bit_sizes) { return CoeffModulus::Create(poly_modulus_degree, bit_sizes); });
+			 [](std::size_t poly_modulus_degree, std::vector<int> bit_sizes) { return CoeffModulus::Create(poly_modulus_degree, bit_sizes); })
 		.def("MaxBitCount",
 			 [](std::size_t poly_modulus_degree) { return CoeffModulus::MaxBitCount(poly_modulus_degree); });
 


### PR DESCRIPTION
Hey another minor change,

I have added a wrap for MaxBitCount which was missing since in my scripts I would like to automatically checking if the provided coefficients exceed the maximum number of bits as touched on in ms-seal comments here: https://github.com/microsoft/SEAL/blob/master/native/examples/4_ckks_basics.cpp#L68-L70
