### PR TITLE
Update Dockerfile to re-enable build of image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 
 # define the folder where our src should exist/ be deposited
 ARG SRC=/python-seal
@@ -12,8 +12,7 @@ RUN apt update && \
     mkdir -p ${SRC}
 
 # copy into container requirements and install them before rest of code
-COPY ./requirements.txt ${SRC}/.
-RUN pip3 install -r ${SRC}/requirements.txt
+RUN pip3 install numpy pybind11
 
 # copy everything into container now that requirements stage is complete
 COPY . ${SRC}


### PR DESCRIPTION
The build of the docker image fails in version 4.0.0 due to 2 problems. This PR fixes both.

* update base image version to fix problem with apt update due to non-reachable repository
* remove usage of requirements.txt as it is not existing